### PR TITLE
Implement transparent theater mode styling

### DIFF
--- a/Chat.js
+++ b/Chat.js
@@ -91,6 +91,65 @@
         return null;
     }
 
+    function applyTheaterStyles() {
+        const player = document.querySelector('.persistent-player--theatre');
+        if (player) {
+            player.style.setProperty('width', '100%', 'important');
+        }
+
+        if (document.querySelector('.bttv-swap-chat .persistent-player--theatre')) {
+            const hideSelectors = [
+                '.top-nav',
+                '.side-nav',
+                '.channel-info-content',
+                '.right-column__toggle-visibility',
+                '.video-chat__header',
+                '.stream-chat-header'
+            ];
+            hideSelectors.forEach(sel => {
+                document.querySelectorAll(sel).forEach(el => {
+                    el.style.setProperty('display', 'none', 'important');
+                });
+            });
+        }
+
+        if (document.querySelector('.right-column--theatre')) {
+            document.querySelectorAll('.top-bar').forEach(el => {
+                el.style.setProperty('top', 'max(0px, calc((100vh - 56.25vw)/2))', 'important');
+                el.style.setProperty('background', 'none', 'important');
+                el.style.setProperty('border', 'none', 'important');
+            });
+
+            document.querySelectorAll('.player-controls, .chat-room, .chat-input-tray__open, .chat-input-container__open').forEach(el => {
+                el.style.setProperty('background', 'none', 'important');
+                el.style.setProperty('border', 'none', 'important');
+            });
+
+            document.querySelectorAll('.channel-root__right-column > div').forEach(el => {
+                el.style.setProperty('background', 'none', 'important');
+                el.style.setProperty('border', 'none', 'important');
+            });
+
+            const rightCol = document.querySelector('.right-column--theatre');
+            if (rightCol) {
+                rightCol.style.setProperty('height', 'min(calc(100vh - (100vh - 56.25vw)/2), 100vh)', 'important');
+                rightCol.style.setProperty('top', 'max(0px, calc((100vh - 56.25vw)/2))', 'important');
+            }
+        }
+
+        document.querySelectorAll('.chat-input').forEach(el => {
+            el.style.setProperty('padding-bottom', '1rem', 'important');
+        });
+
+        if (document.querySelector('.bttv-swap-chat .persistent-player--theatre .chat-shell__expanded')) {
+            document.querySelectorAll('.top-bar, .player-controls').forEach(el => {
+                el.style.setProperty('width', 'calc(100% - 34rem)', 'important');
+                el.style.setProperty('left', '34rem', 'important');
+                el.style.setProperty('opacity', '.7', 'important');
+            });
+        }
+    }
+
     // TODO: Properly distinguish theater mode
     async function applyChatInputStyles(chatInputContainer) {
         let setOpacity = (opacityValue) => {
@@ -405,6 +464,7 @@
                 chatShellFound(chatContainer);
                 // fadeOverflowMessages(chatContainer);
             }
+            applyTheaterStyles();
         }, 100);
     }
 


### PR DESCRIPTION
## Summary
- add `applyTheaterStyles` to replicate uBlock rules in JS
- invoke style updates periodically alongside chat setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fef2a0408333b04d98146ac0406f