### PR TITLE
Fix width of top bar when chat visible

### DIFF
--- a/Chat.js
+++ b/Chat.js
@@ -141,7 +141,7 @@
             el.style.setProperty('padding-bottom', '1rem', 'important');
         });
 
-        if (document.querySelector('.bttv-swap-chat .persistent-player--theatre .chat-shell__expanded')) {
+        if (document.querySelector('.bttv-swap-chat') && document.querySelector('.chat-shell__expanded')) {
             document.querySelectorAll('.top-bar, .player-controls').forEach(el => {
                 el.style.setProperty('width', 'calc(100% - 34rem)', 'important');
                 el.style.setProperty('left', '34rem', 'important');


### PR DESCRIPTION
## Summary
- fix selector in theater layout so top bar and player controls leave room for chat
- run tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842020bbff48333982e91a1d1a015e2