### PR TITLE
Scale heart icon

### DIFF
--- a/Shuffle.js
+++ b/Shuffle.js
@@ -345,7 +345,7 @@ const svgPaths = {
 
     setInterval(function() {
         insertButton('snooze', () => snoozeChannel(), svgPaths.snooze, 'red');
-        insertButton('follow-toggle', () => toggleShuffleType(), svgPaths[shuffleType], 'white');
+        insertButton('follow-toggle', () => toggleShuffleType(), svgPaths[shuffleType], 'white', 0.9);
         insertButton('continuous', () => channelRotationTimer('toggle'), svgPaths.continuous, '#b380ff', 1.1);
 
         // Turn the snooze button red if the current channel is snoozed


### PR DESCRIPTION
## Summary
- make the heart icon 10% smaller using the same scaling approach as the continuous shuffle button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dab9be8108333851d39a2efaa7e21