### PR TITLE
Fix snooze icon placement

### DIFF
--- a/Shuffle.js
+++ b/Shuffle.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Shuffle
 // @namespace    https://github.com/bubbabdfjhgldkfhg/Twitch-Extension
-// @version      1.6
+// @version      1.7
 // @description  Adds a shuffle button to the Twitch video player
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Shuffle.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Shuffle.js
@@ -344,8 +344,8 @@ const svgPaths = {
     }
 
     setInterval(function() {
-        insertButton('snooze', () => snoozeChannel(), svgPaths.snooze, 'red');
         insertButton('follow-toggle', () => toggleShuffleType(), svgPaths[shuffleType], 'white', 0.9);
+        insertButton('snooze', () => snoozeChannel(), svgPaths.snooze, 'red');
         insertButton('continuous', () => channelRotationTimer('toggle'), svgPaths.continuous, '#b380ff', 1.1);
 
         // Turn the snooze button red if the current channel is snoozed


### PR DESCRIPTION
## Summary
- show snooze button after the heart button so it appears on the right
- bump Shuffle userscript version to 1.7

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dad64447c833391b4aac3c184ee94