### PR TITLE
Fix tilde chat overflow

### DIFF
--- a/Chat.js
+++ b/Chat.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Chat
 // @namespace    https://github.com/bubbabdfjhgldkfhg/Twitch-Extension
-// @version      2.6
+// @version      2.7
 // @description  Cleanup clutter from twitch chat
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
@@ -63,6 +63,9 @@
     document.addEventListener('keyup', function(event) {
         if (event.key === '~') {
             tildeHeld = false;
+            if (observer?.targetElement) {
+                fadeOverflowMessages(observer.targetElement);
+            }
             // Re-process all messages with normal filtering
             observer?.disconnect();
             observer = null;


### PR DESCRIPTION
## Summary
- call fadeOverflowMessages when tilde is released so old messages fade
- bump Chat.js version to 2.7

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df3178d1c8333a2244ea233bb3233