### PR TITLE
Fix chat truncation

### DIFF
--- a/Chat.js
+++ b/Chat.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Chat
 // @namespace    https://github.com/bubbabdfjhgldkfhg/Twitch-Extension
-// @version      2.10
+// @version      2.11
 // @description  Cleanup clutter from twitch chat
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
@@ -158,7 +158,7 @@
     }
 
     function toggleAllTruncation(enable) {
-        document.querySelectorAll('.chat-line__message .text-fragment[data-truncated="true"]').forEach(el => {
+        document.querySelectorAll('.chat-line__message [data-truncated="true"]').forEach(el => {
             applyTextTruncation(el, enable);
         });
     }
@@ -344,11 +344,11 @@
         let streamer = window.location.pathname.substring(1);
         let usernameElement = message.querySelector('.chat-author__display-name');
         let username = usernameElement?.textContent;
-        let textElement = message.querySelector('.text-fragment');
-        let text = textElement ? textElement.textContent : '';
-        if (textElement && text.length > 100) {
-            textElement.dataset.truncated = 'true';
-            if (!tildeHeld) applyTextTruncation(textElement, true);
+        let bodyElement = message.querySelector('[data-a-target="chat-line-message-body"]');
+        let text = bodyElement ? bodyElement.textContent : '';
+        if (bodyElement && text.length > 100) {
+            bodyElement.dataset.truncated = 'true';
+            if (!tildeHeld) applyTextTruncation(bodyElement, true);
         }
         let linkElement = message.querySelector('.link-fragment');
 
@@ -465,7 +465,8 @@
         module.exports = {
             isSideConversation,
             hasCyrillic,
-            clipCardAppearance
+            clipCardAppearance,
+            newMessageHandler
         };
     }
 

--- a/chat.test.js
+++ b/chat.test.js
@@ -3,6 +3,7 @@ const {JSDOM} = require('jsdom');
 let isSideConversation;
 let hasCyrillic;
 let clipCardAppearance;
+let newMessageHandler;
 
 describe('chat utilities', () => {
   beforeAll(() => {
@@ -10,7 +11,7 @@ describe('chat utilities', () => {
     global.window = dom.window;
     global.document = dom.window.document;
     document.cookie = 'name=currentuser';
-    ({isSideConversation, hasCyrillic, clipCardAppearance} = require('./Chat.js'));
+    ({isSideConversation, hasCyrillic, clipCardAppearance, newMessageHandler} = require('./Chat.js'));
   });
 
   test('isSideConversation detects reply not involving current user', () => {
@@ -89,5 +90,19 @@ describe('chat utilities', () => {
     expect(level2.style.background).toBe('none');
     expect(level3.style.boxShadow).toBe('none');
     expect(level3.style.borderStyle).toBe('none');
+  });
+
+  test('newMessageHandler truncates long messages', () => {
+    const longText = 'a'.repeat(105);
+    const html = `<div class="chat-line__message"><span data-a-target="chat-line-message-body"><span class="text-fragment">${longText}</span></span></div>`;
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    const message = container.firstElementChild;
+
+    newMessageHandler(message);
+
+    const body = message.querySelector('[data-a-target="chat-line-message-body"]');
+    expect(body.dataset.truncated).toBe('true');
+    expect(body.style.textOverflow).toBe('ellipsis');
   });
 });


### PR DESCRIPTION
## Summary
- fix long-message truncation by targeting chat body instead of only the first fragment
- export `newMessageHandler` for tests
- add regression test for truncation logic
- bump version metadata

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ef952a2f083338b2dc5dfd5ed68cc