### PR TITLE
Fix fetch wrapper for Request objects

### DIFF
--- a/vaft.user.js
+++ b/vaft.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TwitchAdSolutions (vaft)
 // @namespace    https://github.com/pixeltris/TwitchAdSolutions
-// @version      17.0.9
+// @version      17.0.10
 // @description  Multiple solutions for blocking Twitch ads (vaft)
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/vaft.user.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/vaft.user.js
@@ -831,9 +831,17 @@
         var realFetch = window.fetch;
         window.fetch = function(url, init, ...args) {
             console.log('[vaft] fetch', url);
-            init = init || {};
-            if (!init.headers) {
-                init.headers = {};
+            if (url instanceof Request) {
+                const headersFromReq = {};
+                url.headers.forEach((v, k) => headersFromReq[k] = v);
+                init = Object.assign({headers: headersFromReq}, init || {});
+                init.headers = Object.assign({}, headersFromReq, init.headers || {});
+                url = url.url;
+            } else {
+                init = init || {};
+                if (!init.headers) {
+                    init.headers = {};
+                }
             }
             if (typeof url === 'string') {
                 //Check if squad stream.


### PR DESCRIPTION
## Summary
- update `vaft.user.js` to handle `Request` objects in fetch wrapper
- bump version to 17.0.10

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68538f7b4b488333a771f9fdf9c3eed5