### PR TITLE
Fix fetch error by blocking ad noop request

### DIFF
--- a/vaft.user.js
+++ b/vaft.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TwitchAdSolutions (vaft)
 // @namespace    https://github.com/pixeltris/TwitchAdSolutions
-// @version      17.0.16
+// @version      17.0.17
 // @description  Multiple solutions for blocking Twitch ads (vaft)
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/vaft.user.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/vaft.user.js
@@ -13,7 +13,7 @@
 // ==/UserScript==
 (function() {
     'use strict';
-    const SCRIPT_VERSION = '17.0.16';
+    const SCRIPT_VERSION = '17.0.17';
     console.log('[vaft] script loaded', SCRIPT_VERSION);
     var ourTwitchAdSolutionsVersion = 2;// Only bump this when there's a breaking change to Twitch, the script, or there's a conflict with an unmaintained extension which uses this script
     if (window.twitchAdSolutionsVersion && window.twitchAdSolutionsVersion >= ourTwitchAdSolutionsVersion) {
@@ -853,6 +853,10 @@
         var realFetch = window.fetch;
         window.fetch = function(url, init, ...args) {
             console.log('[vaft] fetch', url);
+            if (typeof url === 'string' && url.includes('amazon-adsystem.com')) {
+                console.log('[vaft] blocked noop request', url);
+                return Promise.resolve(new Response('', {status: 200}));
+            }
             if (url instanceof Request) {
                 const headersFromReq = {};
                 url.headers.forEach((v, k) => headersFromReq[k] = v);


### PR DESCRIPTION
## Summary
- avoid failing fetch calls to `amazon-adsystem.com`
- bump `vaft.user.js` version to 17.0.17

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68539f0ef6008333a9fcb09cb7cf3fa0