### PR TITLE
Add vtuber auto-skip in Shuffle

### DIFF
--- a/Shuffle.js
+++ b/Shuffle.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Shuffle
 // @namespace    https://github.com/bubbabdfjhgldkfhg/Twitch-Extension
-// @version      2.4
+// @version      2.5
 // @description  Adds a shuffle button to the Twitch video player
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Shuffle.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Shuffle.js
@@ -400,6 +400,15 @@ const svgPaths = {
             // resetChannelRotationTimer();
         }
     }, 500);
+
+    function vtuberAutoSkip() {
+        if (!autoRotateEnabled) return;
+        const hasVtuberTag = [...document.querySelectorAll('a.tw-tag')]
+            .some(a => (a.textContent || '').trim().toLowerCase() === 'vtuber');
+        if (hasVtuberTag) snoozeChannel();
+    }
+
+    setInterval(vtuberAutoSkip, 2000);
 
     // Enable AirPod & media key controls
     if ('mediaSession' in navigator) {


### PR DESCRIPTION
## Summary
- auto skip channels tagged with `vtuber` when continuous shuffle is active
- bump Shuffle.js version to 2.5

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685466506e308333ba6159f6ed0439bf