### PR TITLE
Improve chat text readability with blend mode

### DIFF
--- a/Chat.js
+++ b/Chat.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Chat
 // @namespace    https://github.com/bubbabdfjhgldkfhg/Twitch-Extension
-// @version      2.13
+// @version      2.14
 // @description  Cleanup clutter from twitch chat
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
@@ -331,6 +331,10 @@
         let usernameElement = message.querySelector('.chat-author__display-name');
         let username = usernameElement?.textContent;
         let bodyElement = message.querySelector('[data-a-target="chat-line-message-body"]');
+        if (bodyElement) {
+            bodyElement.style.mixBlendMode = 'difference';
+            bodyElement.style.color = 'white';
+        }
         let text = bodyElement ? bodyElement.textContent : '';
         let linkElement = message.querySelector('.link-fragment');
 

--- a/chat.test.js
+++ b/chat.test.js
@@ -105,4 +105,17 @@ describe('chat utilities', () => {
     expect(body.dataset.truncated).toBeUndefined();
     expect(body.style.textOverflow).toBe('');
   });
+
+  test('newMessageHandler applies difference blend mode to message text', () => {
+    const html = `<div class="chat-line__message"><span data-a-target="chat-line-message-body"><span class="text-fragment">hi</span></span></div>`;
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    const message = container.firstElementChild;
+
+    newMessageHandler(message);
+
+    const body = message.querySelector('[data-a-target="chat-line-message-body"]');
+    expect(body.style.mixBlendMode).toBe('difference');
+    expect(body.style.color).toBe('white');
+  });
 });


### PR DESCRIPTION
## Summary
- bump chat userscript version to 2.14
- apply `mix-blend-mode: difference` to chat message text
- test new blend mode style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a931d0788333b736dff6501331b1