### PR TITLE
Rollback Chat.js to v2.12

### DIFF
--- a/Chat.js
+++ b/Chat.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Chat
 // @namespace    https://github.com/bubbabdfjhgldkfhg/Twitch-Extension
-// @version      2.14
+// @version      2.12
 // @description  Cleanup clutter from twitch chat
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
@@ -81,17 +81,9 @@
 
     function chatWindowOpacity() {
         let rightColumn = document.querySelector('.channel-root__right-column');
-        if (!rightColumn) return;
-
-        rightColumn.style.transition = 'all 0.25s ease-in-out';
-        let hasMessages = getVisibleMessages().length > 0;
-
-        if (hasMessages) {
-            rightColumn.style.opacity = '1';
+        if (rightColumn) {
+            rightColumn.style.transition = 'all 0.25s ease-in-out';
             rightColumn.style.background = `linear-gradient(90deg, rgba(0,0,0,${brightness/2}) 0%, rgba(0,0,0,0.001) 100%)`;
-        } else {
-            rightColumn.style.opacity = '0';
-            rightColumn.style.background = 'none';
         }
     }
 
@@ -138,7 +130,6 @@
                 oldestMessage.style.transition = 'opacity .5s ease-in-out';
                 oldestMessage.style.opacity = '0';
             }
-            setTimeout(chatWindowOpacity, 600);
         }, 10);
     }
 
@@ -155,14 +146,12 @@
             // message.style.transition = 'opacity .5s ease-in-out';
             message.style.opacity = brightness;
             message.style.setProperty('padding', '.5rem 1.3rem', 'important');
-            chatWindowOpacity();
         }, 0);
 
         // Schedule fade out
         setTimeout(() => {
             message.style.transition = 'opacity 1s ease-in-out';
             message.style.opacity = '0';
-            setTimeout(chatWindowOpacity, 1000);
         }, fadeoutDuration);
     }
 
@@ -331,10 +320,6 @@
         let usernameElement = message.querySelector('.chat-author__display-name');
         let username = usernameElement?.textContent;
         let bodyElement = message.querySelector('[data-a-target="chat-line-message-body"]');
-        if (bodyElement) {
-            bodyElement.style.mixBlendMode = 'difference';
-            bodyElement.style.color = 'white';
-        }
         let text = bodyElement ? bodyElement.textContent : '';
         let linkElement = message.querySelector('.link-fragment');
 

--- a/chat.test.js
+++ b/chat.test.js
@@ -105,17 +105,4 @@ describe('chat utilities', () => {
     expect(body.dataset.truncated).toBeUndefined();
     expect(body.style.textOverflow).toBe('');
   });
-
-  test('newMessageHandler applies difference blend mode to message text', () => {
-    const html = `<div class="chat-line__message"><span data-a-target="chat-line-message-body"><span class="text-fragment">hi</span></span></div>`;
-    const container = document.createElement('div');
-    container.innerHTML = html;
-    const message = container.firstElementChild;
-
-    newMessageHandler(message);
-
-    const body = message.querySelector('[data-a-target="chat-line-message-body"]');
-    expect(body.style.mixBlendMode).toBe('difference');
-    expect(body.style.color).toBe('white');
-  });
 });


### PR DESCRIPTION
## Summary
- revert Chat.js to version 2.12
- align chat tests with the restored script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858ac92c14c8333a6d1a885e7eb2e1f