### PR TITLE
Fix tilde mention visibility

### DIFF
--- a/Chat.js
+++ b/Chat.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Chat
 // @namespace    https://github.com/bubbabdfjhgldkfhg/Twitch-Extension
-// @version      2.12
+// @version      2.13
 // @description  Cleanup clutter from twitch chat
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Chat.js
@@ -32,7 +32,7 @@
                 tildeHeld = true;
                 const messages = document.querySelectorAll('.chat-line__message, .chat-line__status');
                 messages.forEach(message => {
-                    message.style.display = 'block';
+                    message.style.removeProperty('display');
                     message.style.opacity = brightness;
                 });
             }

--- a/chat.test.js
+++ b/chat.test.js
@@ -105,4 +105,19 @@ describe('chat utilities', () => {
     expect(body.dataset.truncated).toBeUndefined();
     expect(body.style.textOverflow).toBe('');
   });
+
+  test('holding tilde reveals mention messages', () => {
+    const message = document.createElement('div');
+    message.className = 'chat-line__message';
+    message.innerHTML = '<span class="mention-fragment">@other</span> hi';
+    document.body.appendChild(message);
+
+    newMessageHandler(message);
+    expect(message.style.display).toBe('none');
+
+    const event = new window.KeyboardEvent('keydown', { key: '~' });
+    document.dispatchEvent(event);
+
+    expect(message.style.display).not.toBe('none');
+  });
 });


### PR DESCRIPTION
## Summary
- update Chat.js version
- restore original display setting when tilde is held so previously hidden messages show
- test that mention messages become visible when tilde is pressed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685da6e581c083339c52163fe4a8b37c