### PR TITLE
Handle ctrl+X in shuffle hotkey

### DIFF
--- a/Shuffle.js
+++ b/Shuffle.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Shuffle
 // @namespace    https://github.com/bubbabdfjhgldkfhg/Twitch-Extension
-// @version      2.5
+// @version      2.6
 // @description  Adds a shuffle button to the Twitch video player
 // @updateURL    https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Shuffle.js
 // @downloadURL  https://raw.githubusercontent.com/bubbabdfjhgldkfhg/Twitch-Extension/main/Shuffle.js
@@ -426,7 +426,9 @@ const svgPaths = {
 
         switch (event.key) {
             case 'x':
-                snoozeChannel();
+                if (!event.ctrlKey) {
+                    snoozeChannel();
+                }
                 break;
             case 'o':
                 channelRotationTimer('disable');


### PR DESCRIPTION
## Summary
- ignore `x` hotkey in Shuffle.js when the Control key is pressed
- bump Shuffle.js `@version`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ff89537a483338a77bf9db1a0d0fb